### PR TITLE
fix(api stacked layout): added tryItOutDefaultServer to TryItContext

### DIFF
--- a/packages/elements/src/components/API/APIWithStackedLayout.tsx
+++ b/packages/elements/src/components/API/APIWithStackedLayout.tsx
@@ -34,6 +34,7 @@ const itemMatchesHash = (hash: string, item: OperationNode) => {
 const TryItContext = React.createContext<{
   hideTryIt?: boolean;
   tryItCredentialsPolicy?: TryItCredentialsPolicy;
+  tryItOutDefaultServer?: string;
   corsProxy?: string;
 }>({
   hideTryIt: false,
@@ -54,7 +55,9 @@ export const APIWithStackedLayout: React.FC<StackedLayoutProps> = ({
   const { groups } = computeTagGroups(serviceNode);
 
   return (
-    <TryItContext.Provider value={{ hideTryIt, tryItCredentialsPolicy, corsProxy: tryItCorsProxy }}>
+    <TryItContext.Provider
+      value={{ hideTryIt, tryItCredentialsPolicy, corsProxy: tryItCorsProxy, tryItOutDefaultServer }}
+    >
       <Flex w="full" flexDirection="col" m="auto" className="sl-max-w-4xl">
         <Box w="full" borderB>
           <Docs
@@ -136,7 +139,7 @@ const Item = React.memo<{ item: OperationNode }>(({ item }) => {
   const scrollRef = React.useRef<HTMLDivElement | null>(null);
   const color = HttpMethodColors[item.data.method] || 'gray';
   const isDeprecated = !!item.data.deprecated;
-  const { hideTryIt, tryItCredentialsPolicy, corsProxy } = React.useContext(TryItContext);
+  const { hideTryIt, tryItCredentialsPolicy, corsProxy, tryItOutDefaultServer } = React.useContext(TryItContext);
 
   const onClick = React.useCallback(() => setIsExpanded(!isExpanded), [isExpanded]);
 
@@ -202,6 +205,7 @@ const Item = React.memo<{ item: OperationNode }>(({ item }) => {
                 <TryItWithRequestSamples
                   httpOperation={item.data}
                   tryItCredentialsPolicy={tryItCredentialsPolicy}
+                  tryItOutDefaultServer={tryItOutDefaultServer}
                   corsProxy={corsProxy}
                 />
               </TabPanel>


### PR DESCRIPTION
Added tryItOutDefaultServer to the TryItContext and use this in the Item component. 

tryItOutDefaultServer was not being utilised by the Api stacked layout. This meant that on mobile, sometimes our try it out requests were failing. On investigation this was because some OAS specs had multiple servers and since tryItOutDefaultServer was not reaching the mobile layout, the first server was being used for requests.