### PR TITLE
fix(api stacked layout) Stacked layout synchronize uri

### DIFF
--- a/packages/elements/src/containers/API.spec.tsx
+++ b/packages/elements/src/containers/API.spec.tsx
@@ -25,12 +25,12 @@ export const APIWithoutRouter = flow(
   withQueryClientProvider,
 )(APIImpl);
 
-// jest.mock('react-router-dom', () => ({
-//   ...jest.requireActual('react-router-dom'),
-//   useLocation: () => ({
-//     pathname: '/operations/get-users',
-//   }),
-// }));
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: () => ({
+    pathname: '/operations/get-users',
+  }),
+}));
 
 describe('API', () => {
   const APIDocument = {
@@ -162,10 +162,10 @@ describe('API', () => {
       expect(usersSummary).toBeInTheDocument();
     });
 
-    // it.only('automatically expands an endpoint if the URI matches the current pathname', () => {
-    //   render(<API logo="thisisarequiredprop" layout="stacked" apiDescriptionDocument={todosApiBundled} />);
-    //   expect(screen.queryByText('Get a user by ID')).toBeInTheDocument();
-    //   expect(screen.queryByRole('heading', { level: 2, name: 'Request' })).toBeInTheDocument();
-    // });
+    it('automatically expands an endpoint if the URI matches the current pathname', () => {
+      render(<API logo="thisisarequiredprop" layout="stacked" apiDescriptionDocument={todosApiBundled} />);
+      expect(screen.queryByText('Get a user by ID')).toBeInTheDocument();
+      expect(screen.queryByRole('heading', { level: 2, name: 'Request' })).toBeInTheDocument();
+    });
   });
 });

--- a/packages/elements/src/containers/API.spec.tsx
+++ b/packages/elements/src/containers/API.spec.tsx
@@ -25,13 +25,6 @@ export const APIWithoutRouter = flow(
   withQueryClientProvider,
 )(APIImpl);
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useLocation: () => ({
-    pathname: '/operations/get-users',
-  }),
-}));
-
 describe('API', () => {
   const APIDocument = {
     ...InstagramAPI,
@@ -163,7 +156,16 @@ describe('API', () => {
     });
 
     it('automatically expands an endpoint if the URI matches the current pathname', () => {
-      render(<API logo="thisisarequiredprop" layout="stacked" apiDescriptionDocument={todosApiBundled} />);
+      const history = createMemoryHistory();
+      history.push('/operations/get-users');
+
+      render(
+        <Router history={history}>
+          <Route path="/">
+            <APIWithoutRouter layout="stacked" apiDescriptionDocument={todosApiBundled} />
+          </Route>
+        </Router>,
+      );
       expect(screen.queryByText('Get a user by ID')).toBeInTheDocument();
       expect(screen.queryByRole('heading', { level: 2, name: 'Request' })).toBeInTheDocument();
     });

--- a/packages/elements/src/containers/API.spec.tsx
+++ b/packages/elements/src/containers/API.spec.tsx
@@ -15,6 +15,7 @@ import { Route, Router } from 'react-router';
 
 import { InstagramAPI } from '../__fixtures__/api-descriptions/Instagram';
 import { simpleApiWithoutDescription } from '../__fixtures__/api-descriptions/simpleApiWithoutDescription';
+import { todosApiBundled } from '../__fixtures__/api-descriptions/todosApiBundled';
 import { API, APIImpl } from './API';
 
 export const APIWithoutRouter = flow(
@@ -23,6 +24,13 @@ export const APIWithoutRouter = flow(
   withMosaicProvider,
   withQueryClientProvider,
 )(APIImpl);
+
+// jest.mock('react-router-dom', () => ({
+//   ...jest.requireActual('react-router-dom'),
+//   useLocation: () => ({
+//     pathname: '/operations/get-users',
+//   }),
+// }));
 
 describe('API', () => {
   const APIDocument = {
@@ -38,7 +46,7 @@ describe('API', () => {
 
   // we need to add scrollTo to the Element prototype before we mount so it has the method available
   Element.prototype.scrollTo = () => {};
-
+  window.HTMLElement.prototype.scrollIntoView = () => {};
   it('displays logo specified in x-logo property of API document', async () => {
     render(<API layout="sidebar" apiDescriptionDocument={InstagramAPI} />);
 
@@ -153,5 +161,11 @@ describe('API', () => {
 
       expect(usersSummary).toBeInTheDocument();
     });
+
+    // it.only('automatically expands an endpoint if the URI matches the current pathname', () => {
+    //   render(<API logo="thisisarequiredprop" layout="stacked" apiDescriptionDocument={todosApiBundled} />);
+    //   expect(screen.queryByText('Get a user by ID')).toBeInTheDocument();
+    //   expect(screen.queryByRole('heading', { level: 2, name: 'Request' })).toBeInTheDocument();
+    // });
   });
 });


### PR DESCRIPTION
Stacked layout was not drilling down to an endpoint shared from the sidebar layout.
We noticed that stacked layout and sidebar layout were looking for hash values in different formats, we've synchronized these to make it possible to share links between desktop and mobile. Additionally, we've added logic to update the URL in mobile when an endpoint is expanded, allowing mobile users to share links.

We removed group expansion tracking from the URL and the associated scroll ref for groups as we currently only care about this for the endpoint level.