### PR TITLE
feat: remove bold from path

### DIFF
--- a/packages/elements-core/src/components/Docs/HttpOperation/HttpOperation.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/HttpOperation.tsx
@@ -143,10 +143,8 @@ function MethodPathInner({ method, path, chosenServerUrl }: MethodPathProps & { 
       <Box dir="rtl" color="muted" textOverflow="truncate" overflowX="hidden">
         <Box as="span" dir="ltr" style={{ unicodeBidi: 'bidi-override' }}>
           {chosenServerUrl}
+          {path}
         </Box>
-      </Box>
-      <Box fontWeight="semibold" flex={1}>
-        {path}
       </Box>
     </Flex>
   );


### PR DESCRIPTION
Currently when trying to copy an endpoint path it creates a new line this is annoying when trying to copy URLs so removing it
