### PR TITLE
feat: removed C# example code as it is broken

### DIFF
--- a/packages/elements-core/src/components/RequestSamples/requestSampleConfigs.ts
+++ b/packages/elements-core/src/components/RequestSamples/requestSampleConfigs.ts
@@ -96,18 +96,19 @@ export const requestSampleConfigs: RequestSampleConfigs = {
     mosaicCodeViewerLanguage: 'ocaml',
     httpSnippetLanguage: 'ocaml',
   },
-  'C#': {
-    mosaicCodeViewerLanguage: 'csharp',
-    httpSnippetLanguage: 'csharp',
-    libraries: {
-      HttpClient: {
-        httpSnippetLibrary: 'httpclient',
-      },
-      RestSharp: {
-        httpSnippetLibrary: 'restsharp',
-      },
-    },
-  },
+  // Removing C# example until the generated code can be fixed
+  // 'C#': {
+  //   mosaicCodeViewerLanguage: 'csharp',
+  //   httpSnippetLanguage: 'csharp',
+  //   libraries: {
+  //     HttpClient: {
+  //       httpSnippetLibrary: 'httpclient',
+  //     },
+  //     RestSharp: {
+  //       httpSnippetLibrary: 'restsharp',
+  //     },
+  //   },
+  // },
   Java: {
     mosaicCodeViewerLanguage: 'java',
     httpSnippetLanguage: 'java',


### PR DESCRIPTION
C# Example code generated is currently broken, commented out C# option until it can be solved.

Code generation is done by a 3rd party library so communication with them will need to be set up to get a fix in.